### PR TITLE
Fix: double-prefix when using permalink()

### DIFF
--- a/src/utils/permalinks.ts
+++ b/src/utils/permalinks.ts
@@ -1,5 +1,3 @@
-import get from 'lodash.get';
-
 /**
  * Helper function to allow permalinks to be referenced by obj.routeName.
  * It also handles adding of the /dev prefix when settings.server is true.
@@ -9,7 +7,6 @@ import get from 'lodash.get';
  */
 const permalinks = ({ routes, settings }) =>
   Object.keys(routes).reduce((out, cv) => {
-
     // eslint-disable-next-line no-param-reassign
     out[cv] = (data) => routes[cv].permalink({ request: data, settings });
     return out;

--- a/src/utils/permalinks.ts
+++ b/src/utils/permalinks.ts
@@ -9,10 +9,9 @@ import get from 'lodash.get';
  */
 const permalinks = ({ routes, settings }) =>
   Object.keys(routes).reduce((out, cv) => {
-    const prefix = settings.prefix || get(settings, 'server.prefix', '');
 
     // eslint-disable-next-line no-param-reassign
-    out[cv] = (data) => `${prefix}${routes[cv].permalink({ request: data, settings })}`;
+    out[cv] = (data) => routes[cv].permalink({ request: data, settings });
     return out;
   }, {});
 


### PR DESCRIPTION
As mentioned here: https://github.com/Elderjs/elderjs/pull/128/files#r571693545